### PR TITLE
TestPlayerRepository could use a temporary path for storage

### DIFF
--- a/digipeli/src/tests/player_repository_test.py
+++ b/digipeli/src/tests/player_repository_test.py
@@ -2,17 +2,27 @@ import unittest
 import os
 from repositories.player_repository import PlayerRepository
 from entities.player import Player
+from tempfile import mkstemp
 
 dirname = os.path.dirname(__file__)
 
 class TestPlayerRepository(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(TestPlayerRepository, self).__init__(*args, **kwargs)
+        self.csv_path = os.path.join(mkstemp(prefix = 'digipeli',
+                                             suffix = '.csv')[1])
+
+
     '''Class for testing the Player class'''
     def setUp(self):
         '''Setting up a player repository'''
-        self.player_repository = PlayerRepository(os.path.join(dirname,
-        "../..", "data", "players-test.csv"))
+        self.player_repository = PlayerRepository(self.csv_path)
         self.player_repository.create(Player("default"))
-        
+
+    def tearDown(self):
+        os.remove(self.csv_path)
+
+
     def test_cannot_add_user_named_default(self):
         '''Test to see that you cannot add a username that is already in use'''
         self.assertRaises(ValueError, lambda: self.player_repository.create(Player("default")))


### PR DESCRIPTION
Project downloaded on 27th April, 10.40AM.

As it stands, `src/tests/player_repository_test.py` uses the same directory for storing data as any "production run" of the project would use. Though the file naming convention ensures there'll be no false positives (or negatives) introduced in the tests from this, the sole existence of a file from a previous test run might do so.

This patch will introduce a change for tests to use a temporary file in a suitable location and a (somewhat redundant) `tearDown` to ensure created files are also removed. The latter is for informational purposes only, as the tests seem to be built in such a way that not every test will require (in the future) a fresh CSV file.