### PR TITLE
Fixes for PlayerRepository to pass all four tests.

### DIFF
--- a/digipeli/data/players-test.csv
+++ b/digipeli/data/players-test.csv
@@ -1,2 +1,0 @@
-player,victories
-default,0

--- a/digipeli/src/entities/player.py
+++ b/digipeli/src/entities/player.py
@@ -1,12 +1,19 @@
 '''Unique players for the game'''
 class Player:
     '''Creates a new player with specified username and 0 victories'''
-    def __init__(self, username: str):
+    def __init__(self, username: str, victories = 0):
         self._username = username
-        self._victories = 0
+        self._victories = victories
 
     def get_name(self):
         return self._username
 
     def get_victories(self):
         return self._victories
+
+    def __str__(self):
+        return (
+            f'{{Player: '
+            f'[username={self._username}, '
+            f'victories={self._victories}]}}'
+        )

--- a/digipeli/src/tests/player_repository_test.py
+++ b/digipeli/src/tests/player_repository_test.py
@@ -2,26 +2,35 @@ import unittest
 import os
 from repositories.player_repository import PlayerRepository
 from entities.player import Player
+from tempfile import mkstemp
 
 dirname = os.path.dirname(__file__)
 
 class TestPlayerRepository(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(TestPlayerRepository, self).__init__(*args, **kwargs)
+        self.csv_path = os.path.join(mkstemp(prefix = 'digipeli',
+                                             suffix = '.csv')[1])
+
+
     '''Class for testing the Player class'''
     def setUp(self):
         '''Setting up a player repository'''
-        self.player_repository = PlayerRepository(os.path.join(dirname,
-        "../..", "data", "players-test.csv"))
+        self.player_repository = PlayerRepository(self.csv_path)
         self.player_repository.create(Player("default"))
-        
+
+    def tearDown(self):
+        os.remove(self.csv_path)
+
     def test_cannot_add_user_named_default(self):
         '''Test to see that you cannot add a username that is already in use'''
         self.assertRaises(ValueError, lambda: self.player_repository.create(Player("default")))
 
     def test_find_username_returns_True_when_looking_for_existing_player(self):
-        self.assertEqual(True, self.player_repository.find_username("default"))
+        self.assertTrue(self.player_repository.find_username("default"))
 
     def test_find_username_returns_False_when_looking_for_nonexisting_player(self):
-        self.assertEqual(False, self.player_repository.find_username("anonymous"))
+        self.assertFalse(self.player_repository.find_username("anonymous"))
 
     def test_find_all_returns_a_dictionary(self):
         self.assertEqual(type(self.player_repository.find_all()), dict)


### PR DESCRIPTION
Project downloaded on 27th April, 10.40AM.

As the subject says, a few fixes (here and there, almost everywhere), to make the tests in PlayerRepositoryTest class pass.

Most changes are in the PlayerRepository class, some of which are more than just cosmetic. The whole idea of the repository representation has been fiddled with: Now the repository holds in memory a list of players, read initially from a CSV file given to the contructor of the class; if and when new players are created using the repository interface, this is reflected into the CSV file, but the file updates are not read unless explicitly instructed so (this, I believe, concurs with the idea behind the repository design pattern).